### PR TITLE
Fixes #3: License indentation missing

### DIFF
--- a/FileEncryptor.go
+++ b/FileEncryptor.go
@@ -1,7 +1,7 @@
 package main
 
 /*
-Copyright 2018 TheRedSpy15
+   Copyright 2018 TheRedSpy15
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@ Copyright 2018 TheRedSpy15
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
-limitations under the License.
+   limitations under the License.
 */
 
 // TODO: document

--- a/MultiGo.go
+++ b/MultiGo.go
@@ -13,7 +13,7 @@ package main
 // TODO: add 'cleanTemp' task
 
 /*
-Copyright 2018 TheRedSpy15
+   Copyright 2018 TheRedSpy15
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ Copyright 2018 TheRedSpy15
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
-limitations under the License.
+   limitations under the License.
 */
 
 import (

--- a/Tasks.go
+++ b/Tasks.go
@@ -1,7 +1,7 @@
 package main
 
 /*
-Copyright 2018 TheRedSpy15
+   Copyright 2018 TheRedSpy15
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@ Copyright 2018 TheRedSpy15
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
-limitations under the License.
+   limitations under the License.
 */
 
 import (

--- a/Utils.go
+++ b/Utils.go
@@ -1,7 +1,7 @@
 package main
 
 /*
-Copyright 2018 TheRedSpy15
+   Copyright 2018 TheRedSpy15
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@ Copyright 2018 TheRedSpy15
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
-limitations under the License.
+   limitations under the License.
 */
 
 import (


### PR DESCRIPTION
Corrects the indentation of the license headers for each `.go` source file.