### PR TITLE
Move Audit logic into own task

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A command line multi-tool made in Go, and aimed at security experts to make life
 - check if account is breached (HaveIBeenPwned)
 - control firewall
 - system security audit
+
 ### Working on (will add more over time):
 - secure file deletion (bleach)
 - file compression/decompression (gzip)
@@ -22,34 +23,38 @@ A command line multi-tool made in Go, and aimed at security experts to make life
 - scrape website(s) for information
 - file encryption/decryption
 - clean temporary files
+
 ## How to
+
 ### Download:
 [Click here to download](https://github.com/TheRedSpy15/Multi-Go/releases/download/0.6.1/MultiGo_0_6_1)
+
 ### Use:
 1. Open the terminal
 2. Paste path to executable
 3. **OPTIONAL:** follow that with "-t/--Task [task] -r/--Target [target]". Note: the 'target' is optional, depending on the task
 4. Hit enter
+
 ### Contribute:
-Simply make a pull pull request, I have yet to turn down one.
+Simply make a pull request, I have yet to turn one down.
 **NOTE:** Currently, I am just relying on TODOS in the comments of the code, as a temporary (as in, will change) replacement for 'issues'
 
-**IMPORTANT:** When working on adding a feature, you must follow this pattern!
-1. Create the method/function to be called in `tasks.go` (with the name "newFeatureTask").
-2. Write all your code in there.
-3. Break that up into multiple functions and put those in `utils.go`.
-4. Go back and add a lot of comments.
+**IMPORTANT:** When adding a new task, you must follow this pattern!
+1. Create a new file in the *tasks* directory and write all of your code there.
+3. If you feel any code in your class may be used in other tasks, feel free to put it in `utils.go`.
+4. Ensure your code is documented well (running *golint* is helpful).
+5. New tasks should have an associated test file (e.g. `mytask_test.go`) in the same folder.
 
 If the new feature is complete:
-1. Add it to the list in `listTasks()`, in `tasks.go`.
-2. Add the case to the switch statement in `main.go`, so it (your new feature in `tasks.go`) can be called.
-3. Finished!
+1. Add the case to the switch statement in `main.go`, so your new task can be called.
+2. Finished!
+
 ## Important
-Multi Go is intended to be used on linux. It might run on Windows. Currently it isn't tested, nor supported! I will eventually work on a Windows patch
+Multi Go is intended to be used on linux. It might run on Windows. Currently it isn't tested, nor supported! I will eventually work on a Windows patch.
 
 ## How to build Multi-Go
 ```
 git clone https://github.com/TheRedSpy15/Multi-Go
 cd Multi-Go
-go build *.go
+go build
 ```

--- a/tasks/audit.go
+++ b/tasks/audit.go
@@ -1,5 +1,13 @@
 package tasks
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/TheRedSpy15/Multi-Go/utils"
+	"github.com/daviddengcn/go-colortext"
+)
+
 /*
    Copyright 2018 TheRedSpy15
 
@@ -16,9 +24,27 @@ package tasks
    limitations under the License.
 */
 
-import "github.com/TheRedSpy15/Multi-Go/utils"
-
 // Audit runs multiple checks and reports found security issues to user
+// TODO: add more checks
+// TODO: add wifi encryption check
+// TODO: add something user related checks
+// TODO: add current software version checks
+// TODO: add using default DNS check
+// TODO: document
 func Audit() {
-	utils.RunAuditOffline()
+	ct.Foreground(ct.Red, true)
+	problems := make([]string, 1)
+
+	fmt.Println("-- Beginning Audit --")
+	fmt.Println("This is a major WIP!")
+	ct.Foreground(ct.Yellow, false)
+
+	// firewall
+	if !strings.Contains(utils.RunCmd("ufw", "status"), "active") { // disabled / is not active
+		problems[0] = "Firewall disabled"
+	}
+	fmt.Println("Check 1 complete!")
+
+	ct.Foreground(ct.Red, true)
+	fmt.Println("Problems found:", problems)
 }

--- a/tasks/toggle_firewall.go
+++ b/tasks/toggle_firewall.go
@@ -18,6 +18,7 @@ package tasks
 
 import (
 	"fmt"
+
 	"github.com/TheRedSpy15/Multi-Go/utils"
 )
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -179,31 +179,6 @@ func Dos(conn net.Conn) {
 	}
 }
 
-// RunAuditOffline audits the system without using a third party service
-// TODO: add more checks
-// TODO: add wifi encryption check
-// TODO: add something user related checks
-// TODO: add current software version checks
-// TODO: add using default DNS check
-// TODO: document
-func RunAuditOffline() {
-	ct.Foreground(ct.Red, true)
-	problems := make([]string, 1)
-
-	fmt.Println("-- Beginning Audit --")
-	fmt.Println("This is a major WIP!")
-	ct.Foreground(ct.Yellow, false)
-
-	// firewall
-	if !strings.Contains(RunCmd("ufw", "status"), "active") { // disabled / is not active
-		problems[0] = "Firewall disabled"
-	}
-	fmt.Println("Check 1 complete!")
-
-	ct.Foreground(ct.Red, true)
-	fmt.Println("Problems found:", problems)
-}
-
 // RandomString returns a random string
 // TODO: rewrite in my own code
 // TODO: add more comments


### PR DESCRIPTION
- The Audit task just called a util method that no other task was using. I moved this util function into the Audit task for simplification. We can break it out later if we feel it needs to be re-used.

- Updated the README to better flow with the new task creation procedure.