### PR TITLE
Added basic byte to gigabyte conversion for printing memory info.

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math"
 	"math/rand"
 	"net"
 	"os"
@@ -31,13 +32,21 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/daviddengcn/go-colortext"
+	ct "github.com/daviddengcn/go-colortext"
 	"github.com/gocolly/colly"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/host"
 	"github.com/shirou/gopsutil/mem"
 	"golang.org/x/crypto/ssh/terminal"
 )
+
+// bytesToGigabytes - a utility function to convert bytes to gigabytes; used to clarify the output of PrintMemory()
+func bytesToGigabytes(bytes uint64) float64 {
+	const conversionFactor = 1000000000
+	result := float64(bytes) / conversionFactor
+	result = float64(math.Round(result*100) / 100)
+	return result
+}
 
 // CheckTarget - checks to see if the target is empty, and panic if is
 func CheckTarget(target string) {
@@ -232,15 +241,15 @@ func PrintCPU() {
 // TODO: get physical memory instead of swap
 // TODO: convert values to gigabytes
 func PrintMemory() {
-	mem, err := mem.SwapMemory() // get virtual memory info object
+	mem, err := mem.VirtualMemory() // get virtual memory info object
 	CheckErr(err)
 
 	ct.Foreground(ct.Red, true) // change text color to bright red
 	fmt.Println("\n-- Memory --")
-	ct.Foreground(ct.Yellow, false)         // change text color to dark yellow
-	fmt.Println("Memory Used:", mem.Used)   // used
-	fmt.Println("Memory Free:", mem.Free)   // free
-	fmt.Println("Memory Total:", mem.Total) // total
+	ct.Foreground(ct.Yellow, false)                                // change text color to dark yellow
+	fmt.Println("Memory Used (Gb):", bytesToGigabytes(mem.Used))   // used
+	fmt.Println("Memory Free (Gb):", bytesToGigabytes(mem.Free))   // free
+	fmt.Println("Memory Total (Gb):", bytesToGigabytes(mem.Total)) // total
 }
 
 // PrintHost - prints info about system host

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -40,8 +40,8 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-// bytesToGigabytes - a utility function to convert bytes to gigabytes; used to clarify the output of PrintMemory()
-func bytesToGigabytes(bytes uint64) float64 {
+// BytesToGigabytes - an internal utility function to convert bytes to gigabytes; used to clarify the output of PrintMemory()
+func BytesToGigabytes(bytes uint64) float64 {
 	const conversionFactor = 1000000000
 	result := float64(bytes) / conversionFactor
 	result = float64(math.Round(result*100) / 100)
@@ -247,9 +247,9 @@ func PrintMemory() {
 	ct.Foreground(ct.Red, true) // change text color to bright red
 	fmt.Println("\n-- Memory --")
 	ct.Foreground(ct.Yellow, false)                                // change text color to dark yellow
-	fmt.Println("Memory Used (Gb):", bytesToGigabytes(mem.Used))   // used
-	fmt.Println("Memory Free (Gb):", bytesToGigabytes(mem.Free))   // free
-	fmt.Println("Memory Total (Gb):", bytesToGigabytes(mem.Total)) // total
+	fmt.Println("Memory Used (Gb):", BytesToGigabytes(mem.Used))   // used
+	fmt.Println("Memory Free (Gb):", BytesToGigabytes(mem.Free))   // free
+	fmt.Println("Memory Total (Gb):", BytesToGigabytes(mem.Total)) // total
 }
 
 // PrintHost - prints info about system host

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 )
 
-func TestbytesToGigabytes(t *testing.T) {
-	got := bytesToGigabytes(4034846720)
+func TestBytesToGigabytes(t *testing.T) {
+	got := BytesToGigabytes(4034846720)
 	want := 4.03
 
 	if got != want {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,30 @@
+package utils
+
+/*
+   Copyright 2018 ScreamingTaco
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"testing"
+)
+
+func TestbytesToGigabytes(t *testing.T) {
+	got := bytesToGigabytes(4034846720)
+	want := 4.03
+
+	if got != want {
+		t.Errorf("got '%f' want '%f'", got, want)
+	}
+}


### PR DESCRIPTION
So I noticed in one of your TODOs that you wanted to convert the memory info to print in gigabytes. I wrote a simple function that converts bytes to gigabytes. Then I changed the PrintMemory function output to use the function. It seems to work. I also wrote a simple test to accompany it. If you want me to write more tests, just tell me which functions you want tested and I'll give it a try :)