### PR TITLE
Fix DOS Task

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func main() {
 		tasks.Scrape(*r)
 	case "DOS":
 		fmt.Println("\nRunning task:", *t, "\nTarget:", *r)
-		tasks.Dos(*r)
+		tasks.Dos(*r, nil)
 	case "compress":
 		fmt.Println("\nRunning task:", *t, "\nTarget:", *r)
 		tasks.Compress(*r)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -23,7 +23,6 @@ import (
 	"log"
 	"math"
 	"math/rand"
-	"net"
 	"os"
 	"os/exec"
 	"os/user"
@@ -35,8 +34,8 @@ import (
 	"github.com/gocolly/colly"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/host"
-	"github.com/shirou/gopsutil/mem"
 	"github.com/shirou/gopsutil/load"
+	"github.com/shirou/gopsutil/mem"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -171,22 +170,6 @@ func CollyAddress(target string, savePage bool, ip bool) {
 	c.Visit(target) // actually using colly/collector object, and visiting target
 }
 
-// Dos - constantly sends data to a target
-// NOTE: this Dos, actually sends data. dos.go creates multiple of this one
-// TODO: not finished yet - randomly stops after a few seconds, works with very limited targets
-// TODO: document
-func Dos(conn net.Conn) {
-	defer conn.Close() // make sure to close the connection when done
-
-	fmt.Println("Starting loop")
-	for true { // DOS loop
-		_, err := fmt.Fprintf(conn, "Sup UDP Server, how you doing?")
-		CheckErr(err)
-
-		fmt.Println("looped")
-	}
-}
-
 // RandomString - returns a random string
 // TODO: rewrite in my own code
 // TODO: add more comments
@@ -224,7 +207,7 @@ func RandomString(length int) string {
 func PrintCPU() {
 	cpuCount, err1 := cpu.Counts(false)       // get cpu count total
 	cpuCountLogical, err2 := cpu.Counts(true) // get cpu logical count
-	cpuLoad, err3 := load.Avg()		  // get current cpu load
+	cpuLoad, err3 := load.Avg()               // get current cpu load
 
 	CheckErr(err1)
 	CheckErr(err2)


### PR DESCRIPTION
This addresses #26. If you feel like there should be more done before this is pulled in, I would be happy to make more additions.

I have fixed the DOS task so it doesn't randomly stop. Previously, there were n+1 deferred calls to `conn.Close()`, where n is the amount of available threads. However, there was nothing preventing `tasks.Dos` from exiting after it started the goroutines, so the connection was being closed at that point.

I also removed some of the verbiage indicating explicit thread usage because it's incorrect. A goroutine is not equivalent to a normal thread.