### PR TITLE
Use Exit instead of Panic

### DIFF
--- a/tasks/dos.go
+++ b/tasks/dos.go
@@ -40,11 +40,10 @@ func Dos(target string, duration *time.Duration) {
 	addr, err := net.ResolveUDPAddr("udp", target)
 	utils.CheckErr(err)
 	conn, err := net.DialUDP("udp", nil, addr) // setup connection object
-	defer conn.Close()                         // make sure to close connection when finished
-
 	utils.CheckErr(err)
+	defer conn.Close() // make sure to close connection when finished
 
-	ct.Foreground(ct.Green, true) // ets text color to bright red
+	ct.Foreground(ct.Green, true) // sets text color to bright green
 	fmt.Println("Checks passed!")
 
 	ct.Foreground(ct.Red, true)                                            // set text color to bright red

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -47,29 +47,27 @@ func BytesToGigabytes(bytes uint64) float64 {
 	return result
 }
 
-// CheckTarget - checks to see if the target is empty, and panic if is
+// CheckTarget throws an error if the target is empty
 func CheckTarget(target string) {
 	if target == "" { // check if target is blank
-		ct.Foreground(ct.Red, true) // set text color to bright red
-		panic("target cannot be empty when performing this task!")
+		CheckErr(fmt.Errorf("target cannot be empty when performing this task"))
 	}
 }
 
-// CheckErr - takes an error & sees if it is not nil
+// CheckErr prints any non-nil errors followed by exiting the application
 func CheckErr(err error) {
 	if err != nil { // check if there actually is any error
 		ct.Foreground(ct.Red, true) // set texts color to bright red
-		panic(err.Error())
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }
 
-// CheckSudo - check if using sudo/root, panic if not
-// TODO: document
+// CheckSudo throws an error if the current user is not sudo/root
 func CheckSudo() {
 	user, _ := user.Current()
 	if !strings.Contains(user.Username, "root") {
-		ct.Foreground(ct.Red, true)
-		panic("cannot run this task without root/sudo!")
+		CheckErr(fmt.Errorf("cannot run this task without root/sudo"))
 	}
 }
 


### PR DESCRIPTION
This addresses my comment in #9. Typically, `panic` means something has gone so wrong we don't know how to even deal with it. The application has reached an unrecoverable state. However, the errors we are getting are easy to deal with. We can just print them to stderr and exit the application with an appropriate error code. I realize this leans more towards personal preference instead of being objectively better, so I understand if you would rather keep things how they are currently.