### PR TITLE
fix installer and add another test

### DIFF
--- a/tasks/install.go
+++ b/tasks/install.go
@@ -52,13 +52,6 @@ func Install(target string) {
 		fmt.Println("Removing old file")
 		err = os.Remove(target)
 		utils.CheckErr(err)
-
-		fmt.Println("Copying to target")
-		err = os.Link(srcPath, target)
-		utils.CheckErr(err)
-
-		fmt.Println("Done")
-		return
 	}
 
 	fmt.Println("Copying to target")

--- a/tasks/install_test.go
+++ b/tasks/install_test.go
@@ -1,7 +1,6 @@
 package tasks
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -36,6 +35,18 @@ func TestInstall(t *testing.T) {
 		} else if files[0].Mode()&0111 == 0 {
 			t.Fatalf("installed file is not executable")
 		}
+		cleanup()
+
+		// check for overwritten file
+		Install(target)
+		Install(target)
+
+		files, err = ioutil.ReadDir(target)
+		if err != nil {
+			t.Fatal(err)
+		} else if files[0].Mode()&0111 == 0 {
+			t.Fatalf("installed file is not executable")
+		}
 	})
 	cleanup()
 
@@ -56,7 +67,6 @@ func TestInstall(t *testing.T) {
 		// write the file
 		err = ioutil.WriteFile(name, []byte("test"), os.ModePerm)
 		if err != nil {
-			fmt.Println("uh oh")
 			t.Fatal(err)
 		}
 


### PR DESCRIPTION
I noticed that you changed the installer to overwrite the file if it already exists instead of exiting. However, the execution bit was not being set in this path. I fixed this, and I also added another test for the installer to check that it overwrites an existing file. I believe once this is pulled in, #32 can be closed.